### PR TITLE
Remove parsec level upper bound

### DIFF
--- a/aeson-qq.cabal
+++ b/aeson-qq.cabal
@@ -1,5 +1,5 @@
 name:                aeson-qq
-version:             0.4.0
+version:             0.4.1
 synopsis:            Json Quasiquatation for Haskell.
 
 -- A longer description of the package.
@@ -25,7 +25,7 @@ cabal-version:       >=1.6
 library
   hs-source-dirs: src
   exposed-modules: Data.Aeson.QQ
-  build-depends: base >= 4.3 && < 5, aeson, parsec >= 2 && < 3, json-qq, template-haskell, haskell-src-meta >= 0.1.0
+  build-depends: base >= 4.3 && < 5, aeson, parsec >= 2, json-qq == 0.4.1, template-haskell, haskell-src-meta >= 0.1.0
 
 source-repository head
   type:     git

--- a/src/Data/Aeson/QQ.hs
+++ b/src/Data/Aeson/QQ.hs
@@ -49,7 +49,7 @@ import Language.Haskell.TH.Quote
 import Data.Data
 import Data.Maybe
 
-import JSON.QQ as QQ
+import Data.JSON.QQ as QQ
 
 import Data.Aeson as A
 import Data.Aeson.Generic


### PR DESCRIPTION
Hi, We should remove the upper bound for parsec version also from aeson-qq. Could you merge this one too and publish 0.4.1?

Cheers, Juha
