### PR TITLE
Allow key interpolation of any `ToJSONKey` type

### DIFF
--- a/src/Data/Aeson/QQ.hs
+++ b/src/Data/Aeson/QQ.hs
@@ -47,7 +47,13 @@ toExp (JsonObject objs) = [|object $jsList|]
       objs2list (key, value) = do
         case key of
           HashStringKey k -> [|(T.pack k, $(toExp value))|]
-          HashVarKey k -> [|(T.pack $(dyn k), $(toExp value))|]
+          HashVarKey k -> [|(case toJSONKey of
+                              ToJSONKeyText toText _ -> toText $(dyn k)
+                              ToJSONKeyValue _ _     ->
+                                error "Quasiquoting array-style keys is unsupported"
+                            , $(toExp value)
+                            )
+                          |]
 toExp (JsonArray arr) = [|Array $ V.fromList $(ListE <$> mapM toExp arr)|]
 toExp (JsonNumber n) = [|Number (fromRational $(return $ LitE $ RationalL (toRational n)))|]
 toExp (JsonBool b) = [|Bool b|]

--- a/test/Data/Aeson/QQSpec.hs
+++ b/test/Data/Aeson/QQSpec.hs
@@ -4,6 +4,7 @@ module Data.Aeson.QQSpec (main, spec) where
 import           Test.Hspec
 
 import           Data.Char
+import           Data.Text (Text)
 import           Data.Aeson
 
 import qualified Person
@@ -40,8 +41,12 @@ spec = do
       [aesonQQ|[null, #{x}]|] `shouldBe` toJSON [Null, x]
 
     it "can interpolate field names" $ do
-      let foo = "zoo"
+      let foo = "zoo" :: String
       [aesonQQ|{$foo: "bar"}|] `shouldBe` object [("zoo", "bar")]
+
+    it "can interpolate text field names" $ do
+      let foo = "too" :: Text
+      [aesonQQ|{$foo: "bar"}|] `shouldBe` object [("too", "bar")]
 
     it "can interpolate numbers" $ do
       let x = 23 :: Int


### PR DESCRIPTION
A QoL improvement I had a need for this morning. 

This allows for `Text` keys, which were previously rejected for not being Strings which could be packed into Text. I haven't added encoding the array-style keys, since that would have required modifying larger parts of the codegen logic.